### PR TITLE
Se revierten los cambios de palabras sobre el Gender

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -29,7 +29,7 @@ export const ENUMS = {
     "Hoka One One",
     "Keen",
     "Under Armour",
-    "Topper",
+    //"Topper",
   ],
   styles: [
     "Basquet",
@@ -54,7 +54,7 @@ export const ENUMS = {
     "Violeta",
   ],
 
-  genders: ["Masculino", "Femenino", "Unisex"],
+  genders: ["Hombre", "Mujer", "Unisex"],
 };
 
 export const { PORT, POSTGRES_URI, SECRET_KEY } = process.env;


### PR DESCRIPTION
Se revierten los cambios de 'Masculino' y 'Femenino' a como estaban originalmente, para evitar conflictos en el front-end. 